### PR TITLE
Fragment detail view

### DIFF
--- a/annotations/models.py
+++ b/annotations/models.py
@@ -146,11 +146,11 @@ class Fragment(models.Model):
                 # TODO: We currently consider only one Annotation per Alignment, YMMV.
                 annotation = alignment.annotation_set.first()
                 if annotation:
-                    result.append(annotation)
+                    result.append((language, annotation))
                 else:
-                    result.append(None)  # This happens if there's no Annotation yet
+                    result.append((language, None))  # This happens if there's no Annotation yet
             else:
-                result.append(None)  # This happens if there's no Alignment for this Fragment in the given language
+                result.append((language, None))  # This happens if there's no Alignment for this Fragment in the given language
         return result
 
     def full(self, marked=False):

--- a/annotations/templates/annotations/fragment_detail.html
+++ b/annotations/templates/annotations/fragment_detail.html
@@ -30,7 +30,7 @@
 
     <h2>Translations</h2>
     {% for annotation in fragment.get_annotations %}
-    {% if forloop.counter|divisibleby:2 %}<div class="row">{% endif %}
+    {% if forloop.counter0|divisibleby:2 %}<div class="row">{% endif %}
         <div class="col-md-6">
             <h3 data-pk="{{ annotation.pk }}">
                 {{ annotation.alignment.translated_fragment.language.title }}

--- a/annotations/templates/annotations/fragment_detail.html
+++ b/annotations/templates/annotations/fragment_detail.html
@@ -11,6 +11,10 @@
 .in-dialogue {
     font-style: italic;
 }
+
+.comments {
+  margin-right: 5px;
+}
 </style>
 
 <div class="container">
@@ -35,6 +39,11 @@
             <h3 data-pk="{{ annotation.pk }}">
                 {{ language }}
                 <span class="label label-primary pull-right">{{ annotation.label }}</span>
+                {% if annotation.comments %}
+                <span class="comments label label-info pull-right" title="{{ annotation.comments }}">
+                  <span class="glyphicon glyphicon-comment"></span>
+                </span>
+                {% endif %}
                 {% if fragment.document.corpus.check_structure and annotation.is_not_same_structure%}
                 <span class="label label-danger pull-right">{% if fragment.formal_structure == 1 %}dialogue{% else %}narration{% endif %}</span>
                 {% endif %}

--- a/annotations/templates/annotations/fragment_detail.html
+++ b/annotations/templates/annotations/fragment_detail.html
@@ -29,17 +29,21 @@
     {% include "annotations/_sentences.html" with sentences=fragment.sentence_set.all tooltips=1 %}
 
     <h2>Translations</h2>
-    {% for annotation in fragment.get_annotations %}
+    {% for language, annotation in fragment.get_annotations %}
     {% if forloop.counter0|divisibleby:2 %}<div class="row">{% endif %}
-        <div class="col-md-6">
+        <div class="col-md-6 {% if not annotation %} text-muted {% endif %}">
             <h3 data-pk="{{ annotation.pk }}">
-                {{ annotation.alignment.translated_fragment.language.title }}
+                {{ language }}
                 <span class="label label-primary pull-right">{{ annotation.label }}</span>
                 {% if fragment.document.corpus.check_structure and annotation.is_not_same_structure%}
                 <span class="label label-danger pull-right">{% if fragment.formal_structure == 1 %}dialogue{% else %}narration{% endif %}</span>
                 {% endif %}
             </h3>
-            {% include "annotations/_sentences.html" with sentences=annotation.alignment.translated_fragment.sentence_set.all tooltips=1 annotated_words=annotation.words.all %}
+            {% if annotation %}
+                {% include "annotations/_sentences.html" with sentences=annotation.alignment.translated_fragment.sentence_set.all tooltips=1 annotated_words=annotation.words.all %}
+            {% else %}
+            No annotation available.
+            {% endif %}
         </div>
     {% if forloop.counter|divisibleby:2 %}</div>{% endif %}
     {% endfor %}

--- a/annotations/templates/annotations/fragment_list.html
+++ b/annotations/templates/annotations/fragment_list.html
@@ -34,7 +34,7 @@
                     {{ fragment.target_words }}
                     {% endif %}
                 </td>
-                {% for annotation in fragment.get_annotations %}
+                {% for _, annotation in fragment.get_annotations %}
                 <td>
                     {% if annotation and annotation.is_translation and not annotation.is_no_target %}
                     <a href="{% url 'annotations:edit' annotation.id %}">


### PR DESCRIPTION
- Displays grayed out boxes for languages in the corpus without an aligned annotation.
- Provides annotation comments in a tooltip.