### PR TITLE
quick solution to allow filtering of annotation fragments by corpus

### DIFF
--- a/annotations/templates/annotations/annotation_form.html
+++ b/annotations/templates/annotations/annotation_form.html
@@ -41,7 +41,7 @@
                 <button type="submit" class="btn btn-primary">
                     {% bootstrap_icon "ok" %} Submit
                 </button>
-                <a href="{% url 'annotations:choose' f1.language.iso f2.language.iso %}" role="button" class="btn btn-warning">
+                <a href="{% url 'annotations:choose' f1.document.corpus.pk f1.language.iso f2.language.iso %}" role="button" class="btn btn-warning">
                     {% bootstrap_icon "arrow-right" %} Go to another fragment
                 </a>
             </form>

--- a/annotations/templates/annotations/home.html
+++ b/annotations/templates/annotations/home.html
@@ -44,7 +44,11 @@
                 </td>
                 <td>
                     {% if annotated < total %}
+                      {% if corpus_pk %}
+                    <a href="{% url 'annotations:choose' corpus_pk l1.iso l2.iso %}" role="button" class="btn btn-default btn-xs" title="Start annotating">
+                      {% else %}
                     <a href="{% url 'annotations:choose' l1.iso l2.iso %}" role="button" class="btn btn-default btn-xs" title="Start annotating">
+                      {% endif %}
                         <span class="glyphicon glyphicon-play" aria-hidden="true"></span>
                     </a>
                     {% endif %}

--- a/annotations/urls.py
+++ b/annotations/urls.py
@@ -12,9 +12,10 @@ urlpatterns = [
     url(r'^status/(?P<pk>\d+)/$', StatusView.as_view(), name='status'),
 
     # Creating and editing Annotations
-    url(r'^create/(?P<pk>\d+)/$', AnnotationCreate.as_view(), name='create'),
+    url(r'^create/(?P<corpus>\d+)/(?P<pk>\d+)/$', AnnotationCreate.as_view(), name='create'),
     url(r'^edit/(?P<pk>\d+)/$', AnnotationUpdate.as_view(), name='edit'),
     url(r'^delete/(?P<pk>\d+)/$', AnnotationDelete.as_view(), name='delete'),
+    url(r'^choose/(?P<corpus>\d+)/(?P<l1>\w+)/(?P<l2>\w+)/$', AnnotationChoose.as_view(), name='choose'),
     url(r'^choose/(?P<l1>\w+)/(?P<l2>\w+)/$', AnnotationChoose.as_view(), name='choose'),
 
     # Showing Fragments

--- a/annotations/utils.py
+++ b/annotations/utils.py
@@ -5,7 +5,7 @@ from django.db.models import Count
 from .models import Corpus, Tense, Alignment, Annotation
 
 
-def get_random_alignment(user, language_from, language_to):
+def get_random_alignment(user, language_from, language_to, corpus=None):
     """
     Retrieves a random Alignment from the database.
     :param user: The current User
@@ -16,8 +16,12 @@ def get_random_alignment(user, language_from, language_to):
     alignments = Alignment.objects \
         .filter(original_fragment__language=language_from) \
         .filter(translated_fragment__language=language_to) \
-        .filter(original_fragment__document__corpus__in=get_available_corpora(user)) \
         .filter(annotation=None)
+
+    if corpus:
+        alignments = alignments.filter(original_fragment__document__corpus__id=corpus)
+    else:
+        alignments = alignments.filter(original_fragment__document__corpus__in=get_available_corpora(user))
 
     return alignments.order_by('?').first()
 

--- a/annotations/views.py
+++ b/annotations/views.py
@@ -159,14 +159,16 @@ class AnnotationChoose(PermissionRequiredMixin, generic.RedirectView):
         """Redirects to a random Alignment"""
         l1 = Language.objects.get(iso=self.kwargs['l1'])
         l2 = Language.objects.get(iso=self.kwargs['l2'])
-        new_alignment = get_random_alignment(self.request.user, l1, l2)
+        corpus = int(self.kwargs['corpus']) if 'corpus' in self.kwargs else None
+        new_alignment = get_random_alignment(self.request.user, l1, l2, corpus)
 
         # If no new alignment has been found, redirect to the status overview
         if not new_alignment:
             messages.success(self.request, 'All work is done for this language pair!')
             return reverse('annotations:status')
 
-        return super(AnnotationChoose, self).get_redirect_url(new_alignment.pk)
+        corpus_pk = new_alignment.original_fragment.document.corpus.pk
+        return super(AnnotationChoose, self).get_redirect_url(corpus_pk, new_alignment.pk)
 
 
 ############


### PR DESCRIPTION
it's not the cleanest solution, but it allows you to choose a corpus on the status overview page, and continue annotating fragments of the same corpus